### PR TITLE
fix: bypass task runner for uploads

### DIFF
--- a/src/service-api.ts
+++ b/src/service-api.ts
@@ -35,6 +35,8 @@ const plugin: FastifyPluginAsync<H5PPluginOptions> = async (fastify, options) =>
     items: { taskManager: itemTaskManager },
     itemMemberships: { taskManager: itemMembershipTaskManager },
     taskRunner,
+    db,
+    log,
   } = fastify;
 
   validatePluginOptions(options);
@@ -88,7 +90,12 @@ const plugin: FastifyPluginAsync<H5PPluginOptions> = async (fastify, options) =>
           mimetype,
         });
 
-        await taskRunner.runSingle(uploadTask);
+        // WARNING: we purposedly bypass the task runner
+        // (this prevents opening unwanted db connections)
+        // TODO: file plugin refactor should be task agnostic and provide a fileService
+        // so we'll simply call fileService.uploadFile in the future
+        await uploadTask.run(db.pool, log);
+
         // we're using flatMap, wrap result in array
         return [childUploadPath];
       }

--- a/test/app.ts
+++ b/test/app.ts
@@ -77,6 +77,7 @@ export async function buildApp(args?: {
 
   const app = fastify();
 
+  app.decorate('db', { pool: dbTrxHandler });
   app.decorate('items', { taskManager: itemTaskManager });
   app.decorate('itemMemberships', { taskManager: itemMembershipTaskManager });
   app.decorate('taskRunner', taskRunner);


### PR DESCRIPTION
Avoid creating unwanted db connections by bypassing the task runner. In the future, use the file service refactor to perform calls directly.