### PR TITLE
fix: run file tasks without db task runner

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,5 +1,6 @@
 import { ErrorFactory } from '@graasp/sdk';
 import { StatusCodes } from 'http-status-codes';
+
 import { PLUGIN_NAME } from './constants';
 
 export const GraaspH5PError = ErrorFactory(PLUGIN_NAME);


### PR DESCRIPTION
Hotfix: replaces file tasks run (previously handled by the task runner, but the tasks have nothing to do with the db).
This should be properly fixed when the file plugin will have been refactored into a proper file service